### PR TITLE
use ncp for non-platform specific raw files copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ make test
 ```
 
 ## Configuration
+Set as many sources as you want. Path should be relative to the `src` directory. The out folder specified in docpad.coffee is used for the destination.
 
-Set as many sources as you want. Path should be relative to the `src` directory. The out folder specified in docpad.coffee is used for the destination
+If no configuration is specified, defaults to `raw` folder
 
 ```
 # ...
@@ -53,6 +54,17 @@ plugins:
             src: 'raw'
             options:
                 clobber: false
+# ...
+```
+
+If you would rather use a shell command
+
+```
+# ...
+plugins:
+    raw:
+        raw:
+            command: ['rsync', '-a', './src/raw/', './out/']
 # ...
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "contributors": [
     "J. Harshbarger <> (https://github.com/hypercubed)",
     "Benjamin Lupton <b@lupton.cc> (https://github.com/balupton)",
-    "Marcus Stong <stongo@gmail.com> (https://github.com/stongo)"
+    "Marcus Stong <stongo@gmail.com> (https://github.com/stongo)",
+    "Rob Loach <robloach@gmail.com> (http://robloach.net)"
   ],
   "bugs": {
     "url": "https://github.com/hypercubed/docpad-plugin-raw/issues"
@@ -30,6 +31,7 @@
   },
   "dependencies": {
     "ncp": "~0.5.0",
+    "bal-util": "~2.0",
     "eachr": "~2.0.2",
     "path": "~0.4.9"
   },


### PR DESCRIPTION
This PR makes the raw plugin work on all platforms with no configuration, and also works on Heroku.
NCP uses node file writes so no longer need to worry about commands per platform, and being dependency free allows it be deployed to hosting platforms like Heroku
